### PR TITLE
Search button missing styling due to its classes defined in "Criteria" instead of "Group"

### DIFF
--- a/src/searchBuilder.bootstrap.ts
+++ b/src/searchBuilder.bootstrap.ts
@@ -12,6 +12,7 @@ $.extend(true, DataTable.Group.classes, {
 	add: 'btn btn-default dtsb-add',
 	clearGroup: 'btn btn-default dtsb-clearGroup',
 	logic: 'btn btn-default dtsb-logic',
+	search: 'btn btn-default dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -20,6 +21,5 @@ $.extend(true, DataTable.Criteria.classes, {
 	delete: 'btn btn-default dtsb-delete',
 	left: 'btn btn-default dtsb-left',
 	right: 'btn btn-default dtsb-right',
-	search: 'btn btn-default dtsb-search',
 	value: 'form-control dtsb-value',
 });

--- a/src/searchBuilder.bootstrap4.ts
+++ b/src/searchBuilder.bootstrap4.ts
@@ -11,7 +11,8 @@ $.extend(true, DataTable.SearchBuilder.classes, {
 $.extend(true, DataTable.Group.classes, {
 	add: 'btn btn-light dtsb-add',
 	clearGroup: 'btn btn-light dtsb-clearGroup',
-	logic: 'btn btn-light dtsb-logic'
+	logic: 'btn btn-light dtsb-logic',
+	search: 'btn btn-light dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -20,6 +21,5 @@ $.extend(true, DataTable.Criteria.classes, {
 	delete: 'btn btn-light dtsb-delete',
 	left: 'btn btn-light dtsb-left',
 	right: 'btn btn-light dtsb-right',
-	search: 'btn btn-light dtsb-search',
 	value: 'form-control dtsb-value',
 });

--- a/src/searchBuilder.bootstrap5.ts
+++ b/src/searchBuilder.bootstrap5.ts
@@ -11,7 +11,8 @@ $.extend(true, DataTable.SearchBuilder.classes, {
 $.extend(true, DataTable.Group.classes, {
 	add: 'btn btn-secondary dtsb-add',
 	clearGroup: 'btn btn-secondary dtsb-clearGroup',
-	logic: 'btn btn-secondary dtsb-logic'
+	logic: 'btn btn-secondary dtsb-logic',
+	search: 'btn btn-secondary dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -21,7 +22,6 @@ $.extend(true, DataTable.Criteria.classes, {
 	input: 'form-control dtsb-input',
 	left: 'btn btn-secondary dtsb-left',
 	right: 'btn btn-secondary dtsb-right',
-	search: 'btn btn-secondary dtsb-search',
 	select: 'form-select',
 	value: 'dtsb-value',
 });

--- a/src/searchBuilder.bulma.ts
+++ b/src/searchBuilder.bulma.ts
@@ -11,13 +11,13 @@ $.extend(true, DataTable.SearchBuilder.classes, {
 $.extend(true, DataTable.Group.classes, {
 	add: 'button dtsb-add',
 	clearGroup: 'button dtsb-clearGroup is-light',
-	logic: 'button dtsb-logic is-light'
+	logic: 'button dtsb-logic is-light',
+	search: 'button dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
 	container: 'dtsb-criteria',
 	delete: 'button dtsb-delete',
 	left: 'button dtsb-left',
-	search: 'button dtsb-search',
 	right: 'button dtsb-right',
 });

--- a/src/searchBuilder.foundation.ts
+++ b/src/searchBuilder.foundation.ts
@@ -12,6 +12,7 @@ $.extend(true, DataTable.Group.classes, {
 	add: 'button dtsb-add',
 	clearGroup: 'button dtsb-clearGroup',
 	logic: 'button dtsb-logic',
+	search: 'button dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -20,6 +21,5 @@ $.extend(true, DataTable.Criteria.classes, {
 	delete: 'button alert dtsb-delete',
 	left: 'button dtsb-left',
 	right: 'button dtsb-right',
-	search: 'button dtsb-search',
 	value: 'form-control dtsb-value',
 });

--- a/src/searchBuilder.jqueryui.ts
+++ b/src/searchBuilder.jqueryui.ts
@@ -12,6 +12,7 @@ $.extend(true, DataTable.Group.classes, {
 	add: 'ui-button ui-corner-all ui-widget dtsb-add',
 	clearGroup: 'ui-button ui-corner-all ui-widget dtsb-clearGroup',
 	logic: 'ui-button ui-corner-all ui-widget dtsb-logic',
+	search: 'ui-button ui-corner-all ui-widget dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -20,6 +21,5 @@ $.extend(true, DataTable.Criteria.classes, {
 	delete: 'ui-button ui-corner-all ui-widget dtsb-delete',
 	left: 'ui-button ui-corner-all ui-widget dtsb-left',
 	right: 'ui-button ui-corner-all ui-widget dtsb-right',
-	search: 'ui-button ui-corner-all ui-widget dtsb-search',
 	value: 'ui-selectmenu-button ui-button ui-widget ui-selectmenu-button-closed ui-corner-all dtsb-value',
 });

--- a/src/searchBuilder.semanticui.ts
+++ b/src/searchBuilder.semanticui.ts
@@ -12,6 +12,7 @@ $.extend(true, DataTable.Group.classes, {
 	add: 'basic ui button dtsb-add',
 	clearGroup: 'basic ui button dtsb-clearGroup',
 	logic: 'basic ui button dtsb-logic',
+	search: 'basic ui button dtsb-search',
 });
 
 $.extend(true, DataTable.Criteria.classes, {
@@ -20,7 +21,6 @@ $.extend(true, DataTable.Criteria.classes, {
 	delete: 'basic ui button dtsb-delete',
 	left: 'basic ui button dtsb-left',
 	right: 'basic ui button dtsb-right',
-	search: 'basic ui button dtsb-search',
 	value: 'basic ui selection dropdown dtsb-value',
 });
 


### PR DESCRIPTION
The search button is defined as part of "Group" and not "Criteria". The Bootstrap styling is therefore not being applied at all to the search button.
Moving the class change for the search button to "Group" fixes this issue.