### PR TITLE
fix: array search for multiple items

### DIFF
--- a/src/criteria.ts
+++ b/src/criteria.ts
@@ -31,7 +31,7 @@ export interface ICondition {
 	) => JQuery<HTMLElement> | Array<JQuery<HTMLElement>> | void;
 	inputValue: (el: JQuery<HTMLElement>) => string[] | void;
 	isInputValid: (val: Array<JQuery<HTMLElement>>, that: Criteria) => boolean;
-	search: (value: string, comparison: string[], that: Criteria) => boolean;
+	search: (value: string | string[], comparison: string[], that: Criteria) => boolean;
 }
 
 export interface IOrthogonal {
@@ -830,7 +830,9 @@ export default class Criteria {
 		// Go through the select elements and push each selected option to the return array
 		for (let element of el) {
 			if (element.is('select')) {
-				values.push(Criteria._escapeHTML(element.children('option:selected').data('sbv')));
+				let escapedItems = [].concat(element.children('option:selected').data('sbv'))
+					.map(item => Criteria._escapeHTML(item));
+                values.push(...escapedItems);
 			}
 		}
 
@@ -1727,7 +1729,7 @@ export default class Criteria {
 			init: Criteria.initSelectArray,
 			inputValue: Criteria.inputValueSelect,
 			isInputValid: Criteria.isInputValidSelect,
-			search(value: string, comparison: string[]) {
+			search(value: string[], comparison: string[]) {
 				return value.includes(comparison[0]);
 			}
 		},
@@ -1738,7 +1740,7 @@ export default class Criteria {
 			init: Criteria.initSelectArray,
 			inputValue: Criteria.inputValueSelect,
 			isInputValid: Criteria.isInputValidSelect,
-			search(value: string, comparison: string[]) {
+			search(value: string[], comparison: string[]) {
 				return value.indexOf(comparison[0]) === -1;
 			}
 		},
@@ -1749,8 +1751,10 @@ export default class Criteria {
 			init: Criteria.initSelect,
 			inputValue: Criteria.inputValueSelect,
 			isInputValid: Criteria.isInputValidSelect,
-			search(value: string, comparison: string[]) {
+			search(value: string[], comparison: string[]) {
 				if (value.length === comparison.length) {
+					// Sort the comparison array to match the already-sorted value array
+                    comparison.sort();
 					for (let i = 0; i < value.length; i++) {
 						if (value[i] !== comparison[i]) {
 							return false;
@@ -1770,8 +1774,10 @@ export default class Criteria {
 			init: Criteria.initSelect,
 			inputValue: Criteria.inputValueSelect,
 			isInputValid: Criteria.isInputValidSelect,
-			search(value: string, comparison: string[]) {
+			search(value: string[], comparison: string[]) {
 				if (value.length === comparison.length) {
+					// Sort the comparison array to match the already-sorted value array
+                    comparison.sort();
 					for (let i = 0; i < value.length; i++) {
 						if (value[i] !== comparison[i]) {
 							return true;
@@ -1795,7 +1801,7 @@ export default class Criteria {
 			isInputValid() {
 				return true;
 			},
-			search(value: string) {
+			search(value: string[]) {
 				return value === null || value === undefined || value.length === 0;
 			}
 		},
@@ -1810,7 +1816,7 @@ export default class Criteria {
 			isInputValid() {
 				return true;
 			},
-			search(value: string) {
+			search(value: string[]) {
 				return value !== null && value !== undefined && value.length !== 0;
 			}
 		},

--- a/src/criteria.ts
+++ b/src/criteria.ts
@@ -832,7 +832,7 @@ export default class Criteria {
 			if (element.is('select')) {
 				let escapedItems = [].concat(element.children('option:selected').data('sbv'))
 					.map(item => Criteria._escapeHTML(item));
-                values.push(...escapedItems);
+				values.push(...escapedItems);
 			}
 		}
 


### PR DESCRIPTION
This is a continue of #25.

Reported in https://datatables.net/forums/discussion/81234.

Previously, I fixed the `search` function for `=` and `!=`, but I didn’t notice that it only works for single item because the input array `comparison` is broken for multiple items before the `search` function is called.

Previously, the input comparison was incorrect after runing the `Criteria._escapeHTML` function. e.g.,  e.g., the output becomes `['Servers,VMs']` after using that. That's why we got nothing when we selected the option for multiple items.

The correct `comparison` array should be `['Servers', 'VMs']`.

One question remains regarding the select option. I noticed that, for example, 
I have 6 rows containg:
A
A
A, B
A, B, C
A, C, B
A, C

The select fills 5 options:
A
A, B
A, C
A, B, C
A, C, B

Note that `A, B, C` and `A, C, B` are actually the same, just in a different order.

But since Search Builder sorts the values, I am forced to also sort the `comparison` array in the search functions, otherwise I wouldn’t get anything if I selected `A, C, B` (using `=`) because the value are already sorted! And we can't find a match.

This is a design question. Currently, my fix will filter both the rows `A, B, C` and `A, C, B` as results.
Feel free to include it under MIT license.